### PR TITLE
Create data base dir in bootstrap

### DIFF
--- a/ci.py
+++ b/ci.py
@@ -981,8 +981,12 @@ class LibvirtCI():
 
         test_dir = data_dir.get_backend_dir('libvirt')
         default_userspace_paths = ["/usr/bin/qemu-kvm", "/usr/bin/qemu-img"]
+        base_dir = data_dir.get_data_dir()
+        if os.path.exists(base_dir):
+            os.unlink(base_dir)
+        os.mkdir(base_dir)
         bootstrap.bootstrap(test_name='libvirt', test_dir=test_dir,
-                            base_dir=data_dir.get_data_dir(),
+                            base_dir=base_dir,
                             default_userspace_paths=default_userspace_paths,
                             check_modules=[],
                             online_docs_url=None,


### PR DESCRIPTION
The base_dir is DATA_DIR by default as "shared/data/" dir under
virt-test, if the dir not exist, a symlink will be created link to
srouce "/var/lib/virt_test/data".

As symlink could not work with semanage and other selinux label
change operation, so create the base_dir before bootstrap to avoid
symlink.

Signed-off-by: Wayne Sun gsun@redhat.com
